### PR TITLE
Sfinktah - d3 (version 4)

### DIFF
--- a/autoload/jslibsyntax.vim
+++ b/autoload/jslibsyntax.vim
@@ -1,7 +1,7 @@
 " Vim plugin file
 " Language:    JS Lib syntax loader
 " Maintainer:  othree <othree@gmail.com>
-" Last Change: 2014/10/30
+" Last Change: 2016/11/11
 " Version:     0.4
 " URL:         https://github.com/othree/javascript-libraries-syntax.vim
 
@@ -21,6 +21,7 @@ let s:libs = [
   \ 'react',
   \ 'flux',
   \ 'handlebars',
+  \ 'd3',
   \ 'vue'
   \ ]
 

--- a/autoload/syntax/d3.coffee.vim
+++ b/autoload/syntax/d3.coffee.vim
@@ -1,0 +1,109 @@
+" Vim syntax file
+" Language:    d3.v4 for coffee
+" Maintainer:  othree <othree@gmail.com>
+" Maintainer:  Sfinktah <sfinktah@othree.spamtrak.org>
+" Last Change: 2016/11/11
+" Version:     4.2.8.0
+" URL:         https://github.com/d3/d3/blob/master/API.md
+
+syntax keyword coffeeD3 d3                      containedin=ALLBUT,coffeeComment,coffeeLineComment,coffeeString,coffeeTemplate,coffeeTemplateSubstitution
+syntax cluster coffee_Functions                 contains=@coffeeD3Arrays,coffeeD3Axes,coffeeD3Brushes,coffeeD3Chords,@coffeeD3Collections,coffeeD3Colors,coffeeD3Dispatches,coffeeD3Dragging,coffeeD3DelimiterSeparatedValues,coffeeD3Easings,coffeeD3Forces,coffeeD3NumberFormats,coffeeD3Geographies,coffeeD3GeographiesStreams,coffeeD3GeographiesTransforms,coffeeD3Hierarchies,coffeeD3Interpolators,coffeeD3Paths,coffeeD3Polygons,coffeeD3Quadtrees,coffeeD3Queues,coffeeD3RandomNumbers,coffeeD3Requests,coffeeD3Scales,coffeeD3Selections,coffeeD3Shapes,coffeeD3TimeFormats,coffeeD3TimeIntervals,coffeeD3Timers,coffeeD3Transitions,coffeeD3VoronoiDiagrams,coffeeD3Zooming
+
+syntax cluster coffeeD3Arrays	                  contains=coffeeD3ArraysStatistics,coffeeD3ArraysSearch,coffeeD3ArraysTransformations,coffeeD3ArraysHistograms,coffeeD3Axes,coffeeD3Arrays
+syntax keyword coffeeD3ArraysStatistics         contained min max extent sum mean median quantile variance deviation
+syntax keyword coffeeD3ArraysSearch             contained scan bisect bisectRight bisectLeft bisector ascending descending
+syntax keyword coffeeD3ArraysTransformations    contained merge pairs permute shuffle ticks tickStep range transpose zip
+syntax keyword coffeeD3ArraysHistograms         contained histogram thresholdFreedmanDiaconis thresholdScott thresholdSturges
+syntax keyword coffeeD3Axes                     contained axisTop axisRight axisBottom axisLeft
+syntax keyword coffeeD3Brushes                  contained brush brushX brushY brushSelection
+syntax keyword coffeeD3Chords                   contained chord ribbon
+
+syntax cluster coffeeD3Collections              contains=coffeeD3CollectionsObjects,coffeeD3CollectionsMaps,coffeeD3CollectionsSets,coffeeD3CollectionsNests
+syntax keyword coffeeD3CollectionsObjects       contained keys values entries
+syntax keyword coffeeD3CollectionsMaps          contained map
+syntax keyword coffeeD3CollectionsSets          contained set
+syntax keyword coffeeD3CollectionsNests         contained nest
+
+syntax keyword coffeeD3Colors                   contained color rgb hsl lab hcl cubehelix
+syntax keyword coffeeD3Dispatches               contained dispatch
+syntax keyword coffeeD3Dragging                 contained drag dragDisable dragEnable
+syntax keyword coffeeD3DelimiterSeparatedValues contained dsvFormat csvParse csvParseRows csvFormat csvFormatRows tsvParse tsvParseRows tsvFormat tsvFormatRows
+syntax keyword coffeeD3Easings                  contained easeLinear easePolyIn easePolyOut easePolyInOut easeQuad easeQuadIn easeQuadOut easeQuadInOut easeCubic easeCubicIn easeCubicOut easeCubicInOut easeSin easeSinIn easeSinOut easeSinInOut easeExp easeExpIn easeExpOut easeExpInOut easeCircle easeCircleIn easeCircleOut easeCircleInOut easeElastic easeElasticIn easeElasticOut easeElasticInOut easeBack easeBackIn easeBackOut easeBackInOut easeBounce easeBounceIn easeBounceOut easeBounceInOut
+syntax keyword coffeeD3Forces                   contained forceSimulation forceCenter forceCollide forceLink forceManyBody forceX forceY
+syntax keyword coffeeD3NumberFormats            contained format formatPrefix formatSpecifier formatLocale formatDefaultLocale precisionFixed precisionPrefix precisionRound
+syntax keyword coffeeD3Geographies              contained geoPath geoAlbers geoAlbersUsa geoAzimuthalEqualArea geoAzimuthalEquidistant geoConicConformal geoConicEqualArea geoConicEquidistant geoEquirectangular geoGnomonic geoMercator geoOrthographic geoStereographic geoTransverseMercator geoProjection geoProjectionMutator geoAzimuthalEqualAreaRaw geoAzimuthalEquidistantRaw geoConicConformalRaw geoConicEqualAreaRaw geoConicEquidistantRaw geoEquirectangularRaw geoGnomonicRaw geoMercatorRaw geoOrthographicRaw geoStereographicRaw geoTransverseMercatorRaw geoArea geoBounds geoCentroid geoDistance geoLength geoInterpolate geoRotation geoCircle geoGraticule geoClipExtent
+syntax keyword coffeeD3GeographiesStreams       contained geoStream
+syntax keyword coffeeD3GeographiesTransforms    contained geoIdentity geoTransform
+syntax keyword coffeeD3Hierarchies              contained hierarchy stratify cluster tree treemap treemapBinary treemapDice treemapSlice treemapSliceDice treemapSquarify treemapResquarify partition pack packSiblings packEnclose
+syntax keyword coffeeD3Interpolators            contained interpolate interpolateArray interpolateDate interpolateNumber interpolateObject interpolateRound interpolateString interpolateTransformCss interpolateTransformSvg interpolateZoom interpolateRgb interpolateRgbBasis interpolateRgbBasisClosed interpolateHsl interpolateHslLong interpolateLab interpolateHcl interpolateHclLong interpolateCubehelix interpolateCubehelixLong interpolateBasis interpolateBasisClosed quantize
+syntax keyword coffeeD3Paths                    contained path
+syntax keyword coffeeD3Polygons                 contained polygonArea polygonCentroid polygonHull polygonContains polygonLength
+syntax keyword coffeeD3Quadtrees                contained quadtree
+syntax keyword coffeeD3Queues                   contained queue
+syntax keyword coffeeD3RandomNumbers            contained randomUniform randomNormal randomLogNormal randomBates randomIrwinHall randomExponential
+syntax keyword coffeeD3Requests                 contained request csv html json text tsv xml
+syntax keyword coffeeD3Scales                   contained scaleLinear scalePow scaleSqrt scaleLog scaleIdentity scaleTime scaleUtc scaleSequential interpolateViridis interpolateInferno interpolateMagma interpolatePlasma interpolateWarm interpolateCool interpolateRainbow interpolateCubehelixDefault scaleQuantize scaleQuantile scaleThreshold scaleOrdinal scaleImplicit scaleBand scalePoint schemeCategory10 schemeCategory20 schemeCategory20b schemeCategory20c
+syntax keyword coffeeD3Selections               contained selection select selectAll matcher selector selectorAll window creator event customEvent mouse touch touches local namespace namespaces
+syntax keyword coffeeD3Shapes                   contained arc pie line radialLine area radialArea curveBasis curveBasisClosed curveBasisOpen curveBundle curveCardinal curveCardinalClosed curveCardinalOpen curveCatmullRom curveCatmullRomClosed curveCatmullRomOpen curveLinear curveLinearClosed curveMonotoneX curveMonotoneY curveNatural curveStep curveStepAfter curveStepBefore symbol symbols symbolCircle symbolCross symbolDiamond symbolSquare symbolStar symbolTriangle symbolWye stack stackOrderAscending stackOrderDescending stackOrderInsideOut stackOrderNone stackOrderReverse stackOffsetExpand stackOffsetNone stackOffsetSilhouette stackOffsetWiggle
+syntax keyword coffeeD3TimeFormats              contained timeFormat timeParse utcFormat utcParse isoFormat isoParse timeFormatLocale timeFormatDefaultLocale
+syntax keyword coffeeD3TimeIntervals            contained timeInterval timeMillisecond utcMillisecond timeMilliseconds utcMilliseconds timeSecond utcSecond timeSeconds utcSeconds timeMinute utcMinute timeMinutes utcMinutes timeHour utcHour timeHours utcHours timeDay utcDay timeDays utcDays timeWeek utcWeek timeWeeks utcWeeks timeSunday utcSunday timeSundays utcSundays timeMonday utcMonday timeMondays utcMondays timeTuesday utcTuesday timeTuesdays utcTuesdays timeWednesday utcWednesday timeWednesdays utcWednesdays timeThursday utcThursday timeThursdays utcThursdays timeFriday utcFriday timeFridays utcFridays timeSaturday utcSaturday timeSaturdays utcSaturdays timeMonth utcMonth timeMonths utcMonths timeYear utcYear timeYears utcYears
+syntax keyword coffeeD3Timers                   contained now timer timerFlush timeout interval
+syntax keyword coffeeD3Transitions              contained transition active interrupt
+syntax keyword coffeeD3VoronoiDiagrams          contained voronoi
+syntax keyword coffeeD3Zooming                  contained zoom zoomTransform zoomIdentity
+
+" Define the default highlighting.
+" For version 5.7 and earlier: only when not done already
+" For version 5.8 and later: only when an item doesn't have highlighting yet
+if version >= 508 || !exists("did_underscore_coffee_syntax_inits")
+  if version < 508
+    let did_underscore_coffee_syntax_inits = 1
+    command -nargs=+ HiLink hi link <args>
+  else
+    command -nargs=+ HiLink hi def link <args>
+  endif
+
+  HiLink coffeeD3                         Constant
+  HiLink coffeeD3ArraysStatistics         PreProc
+  HiLink coffeeD3ArraysSearch             PreProc
+  HiLink coffeeD3ArraysTransformations    PreProc
+  HiLink coffeeD3ArraysHistograms         PreProc
+  HiLink coffeeD3Axes                     PreProc
+  HiLink coffeeD3Brushes                  PreProc
+  HiLink coffeeD3Chords                   PreProc
+  HiLink coffeeD3CollectionsObjects       PreProc
+  HiLink coffeeD3CollectionsMaps          PreProc
+  HiLink coffeeD3CollectionsSets          PreProc
+  HiLink coffeeD3CollectionsNests         PreProc
+  HiLink coffeeD3Colors                   PreProc
+  HiLink coffeeD3Dispatches               PreProc
+  HiLink coffeeD3Dragging                 PreProc
+  HiLink coffeeD3DelimiterSeparatedValues PreProc
+  HiLink coffeeD3Easings                  PreProc
+  HiLink coffeeD3Forces                   PreProc
+  HiLink coffeeD3NumberFormats            PreProc
+  HiLink coffeeD3Geographies              PreProc
+  HiLink coffeeD3GeographiesStreams       PreProc
+  HiLink coffeeD3GeographiesTransforms    PreProc
+  HiLink coffeeD3Hierarchies              PreProc
+  HiLink coffeeD3Interpolators            PreProc
+  HiLink coffeeD3Paths                    PreProc
+  HiLink coffeeD3Polygons                 PreProc
+  HiLink coffeeD3Quadtrees                PreProc
+  HiLink coffeeD3Queues                   PreProc
+  HiLink coffeeD3RandomNumbers            PreProc
+  HiLink coffeeD3Requests                 PreProc
+  HiLink coffeeD3Scales                   PreProc
+  HiLink coffeeD3Selections               PreProc
+  HiLink coffeeD3Shapes                   PreProc
+  HiLink coffeeD3TimeFormats              PreProc
+  HiLink coffeeD3TimeIntervals            PreProc
+  HiLink coffeeD3Timers                   PreProc
+  HiLink coffeeD3Transitions              PreProc
+  HiLink coffeeD3VoronoiDiagrams          PreProc
+  HiLink coffeeD3Zooming                  PreProc
+
+  delcommand HiLink
+endif
+
+

--- a/autoload/syntax/d3.javascript.vim
+++ b/autoload/syntax/d3.javascript.vim
@@ -1,0 +1,109 @@
+" Vim syntax file
+" Language:    d3.v4 for javascript
+" Maintainer:  othree <othree@gmail.com>
+" Maintainer:  Sfinktah <sfinktah@othree.spamtrak.org>
+" Last Change: 2016/11/11
+" Version:     4.2.8.0
+" URL:         https://github.com/d3/d3/blob/master/API.md
+
+syntax keyword javascriptD3 d3                      containedin=ALLBUT,javascriptComment,javascriptLineComment,javascriptString,javascriptTemplate,javascriptTemplateSubstitution
+syntax cluster javascript_Functions                 contains=@javascriptD3Arrays,javascriptD3Axes,javascriptD3Brushes,javascriptD3Chords,@javascriptD3Collections,javascriptD3Colors,javascriptD3Dispatches,javascriptD3Dragging,javascriptD3DelimiterSeparatedValues,javascriptD3Easings,javascriptD3Forces,javascriptD3NumberFormats,javascriptD3Geographies,javascriptD3GeographiesStreams,javascriptD3GeographiesTransforms,javascriptD3Hierarchies,javascriptD3Interpolators,javascriptD3Paths,javascriptD3Polygons,javascriptD3Quadtrees,javascriptD3Queues,javascriptD3RandomNumbers,javascriptD3Requests,javascriptD3Scales,javascriptD3Selections,javascriptD3Shapes,javascriptD3TimeFormats,javascriptD3TimeIntervals,javascriptD3Timers,javascriptD3Transitions,javascriptD3VoronoiDiagrams,javascriptD3Zooming
+
+syntax cluster javascriptD3Arrays	                  contains=javascriptD3ArraysStatistics,javascriptD3ArraysSearch,javascriptD3ArraysTransformations,javascriptD3ArraysHistograms,javascriptD3Axes,javascriptD3Arrays
+syntax keyword javascriptD3ArraysStatistics         contained min max extent sum mean median quantile variance deviation
+syntax keyword javascriptD3ArraysSearch             contained scan bisect bisectRight bisectLeft bisector ascending descending
+syntax keyword javascriptD3ArraysTransformations    contained merge pairs permute shuffle ticks tickStep range transpose zip
+syntax keyword javascriptD3ArraysHistograms         contained histogram thresholdFreedmanDiaconis thresholdScott thresholdSturges
+syntax keyword javascriptD3Axes                     contained axisTop axisRight axisBottom axisLeft
+syntax keyword javascriptD3Brushes                  contained brush brushX brushY brushSelection
+syntax keyword javascriptD3Chords                   contained chord ribbon
+
+syntax cluster javascriptD3Collections              contains=javascriptD3CollectionsObjects,javascriptD3CollectionsMaps,javascriptD3CollectionsSets,javascriptD3CollectionsNests
+syntax keyword javascriptD3CollectionsObjects       contained keys values entries
+syntax keyword javascriptD3CollectionsMaps          contained map
+syntax keyword javascriptD3CollectionsSets          contained set
+syntax keyword javascriptD3CollectionsNests         contained nest
+
+syntax keyword javascriptD3Colors                   contained color rgb hsl lab hcl cubehelix
+syntax keyword javascriptD3Dispatches               contained dispatch
+syntax keyword javascriptD3Dragging                 contained drag dragDisable dragEnable
+syntax keyword javascriptD3DelimiterSeparatedValues contained dsvFormat csvParse csvParseRows csvFormat csvFormatRows tsvParse tsvParseRows tsvFormat tsvFormatRows
+syntax keyword javascriptD3Easings                  contained easeLinear easePolyIn easePolyOut easePolyInOut easeQuad easeQuadIn easeQuadOut easeQuadInOut easeCubic easeCubicIn easeCubicOut easeCubicInOut easeSin easeSinIn easeSinOut easeSinInOut easeExp easeExpIn easeExpOut easeExpInOut easeCircle easeCircleIn easeCircleOut easeCircleInOut easeElastic easeElasticIn easeElasticOut easeElasticInOut easeBack easeBackIn easeBackOut easeBackInOut easeBounce easeBounceIn easeBounceOut easeBounceInOut
+syntax keyword javascriptD3Forces                   contained forceSimulation forceCenter forceCollide forceLink forceManyBody forceX forceY
+syntax keyword javascriptD3NumberFormats            contained format formatPrefix formatSpecifier formatLocale formatDefaultLocale precisionFixed precisionPrefix precisionRound
+syntax keyword javascriptD3Geographies              contained geoPath geoAlbers geoAlbersUsa geoAzimuthalEqualArea geoAzimuthalEquidistant geoConicConformal geoConicEqualArea geoConicEquidistant geoEquirectangular geoGnomonic geoMercator geoOrthographic geoStereographic geoTransverseMercator geoProjection geoProjectionMutator geoAzimuthalEqualAreaRaw geoAzimuthalEquidistantRaw geoConicConformalRaw geoConicEqualAreaRaw geoConicEquidistantRaw geoEquirectangularRaw geoGnomonicRaw geoMercatorRaw geoOrthographicRaw geoStereographicRaw geoTransverseMercatorRaw geoArea geoBounds geoCentroid geoDistance geoLength geoInterpolate geoRotation geoCircle geoGraticule geoClipExtent
+syntax keyword javascriptD3GeographiesStreams       contained geoStream
+syntax keyword javascriptD3GeographiesTransforms    contained geoIdentity geoTransform
+syntax keyword javascriptD3Hierarchies              contained hierarchy stratify cluster tree treemap treemapBinary treemapDice treemapSlice treemapSliceDice treemapSquarify treemapResquarify partition pack packSiblings packEnclose
+syntax keyword javascriptD3Interpolators            contained interpolate interpolateArray interpolateDate interpolateNumber interpolateObject interpolateRound interpolateString interpolateTransformCss interpolateTransformSvg interpolateZoom interpolateRgb interpolateRgbBasis interpolateRgbBasisClosed interpolateHsl interpolateHslLong interpolateLab interpolateHcl interpolateHclLong interpolateCubehelix interpolateCubehelixLong interpolateBasis interpolateBasisClosed quantize
+syntax keyword javascriptD3Paths                    contained path
+syntax keyword javascriptD3Polygons                 contained polygonArea polygonCentroid polygonHull polygonContains polygonLength
+syntax keyword javascriptD3Quadtrees                contained quadtree
+syntax keyword javascriptD3Queues                   contained queue
+syntax keyword javascriptD3RandomNumbers            contained randomUniform randomNormal randomLogNormal randomBates randomIrwinHall randomExponential
+syntax keyword javascriptD3Requests                 contained request csv html json text tsv xml
+syntax keyword javascriptD3Scales                   contained scaleLinear scalePow scaleSqrt scaleLog scaleIdentity scaleTime scaleUtc scaleSequential interpolateViridis interpolateInferno interpolateMagma interpolatePlasma interpolateWarm interpolateCool interpolateRainbow interpolateCubehelixDefault scaleQuantize scaleQuantile scaleThreshold scaleOrdinal scaleImplicit scaleBand scalePoint schemeCategory10 schemeCategory20 schemeCategory20b schemeCategory20c
+syntax keyword javascriptD3Selections               contained selection select selectAll matcher selector selectorAll window creator event customEvent mouse touch touches local namespace namespaces
+syntax keyword javascriptD3Shapes                   contained arc pie line radialLine area radialArea curveBasis curveBasisClosed curveBasisOpen curveBundle curveCardinal curveCardinalClosed curveCardinalOpen curveCatmullRom curveCatmullRomClosed curveCatmullRomOpen curveLinear curveLinearClosed curveMonotoneX curveMonotoneY curveNatural curveStep curveStepAfter curveStepBefore symbol symbols symbolCircle symbolCross symbolDiamond symbolSquare symbolStar symbolTriangle symbolWye stack stackOrderAscending stackOrderDescending stackOrderInsideOut stackOrderNone stackOrderReverse stackOffsetExpand stackOffsetNone stackOffsetSilhouette stackOffsetWiggle
+syntax keyword javascriptD3TimeFormats              contained timeFormat timeParse utcFormat utcParse isoFormat isoParse timeFormatLocale timeFormatDefaultLocale
+syntax keyword javascriptD3TimeIntervals            contained timeInterval timeMillisecond utcMillisecond timeMilliseconds utcMilliseconds timeSecond utcSecond timeSeconds utcSeconds timeMinute utcMinute timeMinutes utcMinutes timeHour utcHour timeHours utcHours timeDay utcDay timeDays utcDays timeWeek utcWeek timeWeeks utcWeeks timeSunday utcSunday timeSundays utcSundays timeMonday utcMonday timeMondays utcMondays timeTuesday utcTuesday timeTuesdays utcTuesdays timeWednesday utcWednesday timeWednesdays utcWednesdays timeThursday utcThursday timeThursdays utcThursdays timeFriday utcFriday timeFridays utcFridays timeSaturday utcSaturday timeSaturdays utcSaturdays timeMonth utcMonth timeMonths utcMonths timeYear utcYear timeYears utcYears
+syntax keyword javascriptD3Timers                   contained now timer timerFlush timeout interval
+syntax keyword javascriptD3Transitions              contained transition active interrupt
+syntax keyword javascriptD3VoronoiDiagrams          contained voronoi
+syntax keyword javascriptD3Zooming                  contained zoom zoomTransform zoomIdentity
+
+" Define the default highlighting.
+" For version 5.7 and earlier: only when not done already
+" For version 5.8 and later: only when an item doesn't have highlighting yet
+if version >= 508 || !exists("did_underscore_javascript_syntax_inits")
+  if version < 508
+    let did_underscore_javascript_syntax_inits = 1
+    command -nargs=+ HiLink hi link <args>
+  else
+    command -nargs=+ HiLink hi def link <args>
+  endif
+
+  HiLink javascriptD3                         Constant
+  HiLink javascriptD3ArraysStatistics         PreProc
+  HiLink javascriptD3ArraysSearch             PreProc
+  HiLink javascriptD3ArraysTransformations    PreProc
+  HiLink javascriptD3ArraysHistograms         PreProc
+  HiLink javascriptD3Axes                     PreProc
+  HiLink javascriptD3Brushes                  PreProc
+  HiLink javascriptD3Chords                   PreProc
+  HiLink javascriptD3CollectionsObjects       PreProc
+  HiLink javascriptD3CollectionsMaps          PreProc
+  HiLink javascriptD3CollectionsSets          PreProc
+  HiLink javascriptD3CollectionsNests         PreProc
+  HiLink javascriptD3Colors                   PreProc
+  HiLink javascriptD3Dispatches               PreProc
+  HiLink javascriptD3Dragging                 PreProc
+  HiLink javascriptD3DelimiterSeparatedValues PreProc
+  HiLink javascriptD3Easings                  PreProc
+  HiLink javascriptD3Forces                   PreProc
+  HiLink javascriptD3NumberFormats            PreProc
+  HiLink javascriptD3Geographies              PreProc
+  HiLink javascriptD3GeographiesStreams       PreProc
+  HiLink javascriptD3GeographiesTransforms    PreProc
+  HiLink javascriptD3Hierarchies              PreProc
+  HiLink javascriptD3Interpolators            PreProc
+  HiLink javascriptD3Paths                    PreProc
+  HiLink javascriptD3Polygons                 PreProc
+  HiLink javascriptD3Quadtrees                PreProc
+  HiLink javascriptD3Queues                   PreProc
+  HiLink javascriptD3RandomNumbers            PreProc
+  HiLink javascriptD3Requests                 PreProc
+  HiLink javascriptD3Scales                   PreProc
+  HiLink javascriptD3Selections               PreProc
+  HiLink javascriptD3Shapes                   PreProc
+  HiLink javascriptD3TimeFormats              PreProc
+  HiLink javascriptD3TimeIntervals            PreProc
+  HiLink javascriptD3Timers                   PreProc
+  HiLink javascriptD3Transitions              PreProc
+  HiLink javascriptD3VoronoiDiagrams          PreProc
+  HiLink javascriptD3Zooming                  PreProc
+
+  delcommand HiLink
+endif
+
+

--- a/autoload/syntax/d3.ls.vim
+++ b/autoload/syntax/d3.ls.vim
@@ -1,0 +1,109 @@
+" Vim syntax file
+" Language:    d3.v4 for ls
+" Maintainer:  othree <othree@gmail.com>
+" Maintainer:  Sfinktah <sfinktah@othree.spamtrak.org>
+" Last Change: 2016/11/11
+" Version:     4.2.8.0
+" URL:         https://github.com/d3/d3/blob/master/API.md
+
+syntax keyword lsD3 d3                      containedin=ALLBUT,lsComment,lsLineComment,lsString,lsTemplate,lsTemplateSubstitution
+syntax cluster ls_Functions                 contains=@lsD3Arrays,lsD3Axes,lsD3Brushes,lsD3Chords,@lsD3Collections,lsD3Colors,lsD3Dispatches,lsD3Dragging,lsD3DelimiterSeparatedValues,lsD3Easings,lsD3Forces,lsD3NumberFormats,lsD3Geographies,lsD3GeographiesStreams,lsD3GeographiesTransforms,lsD3Hierarchies,lsD3Interpolators,lsD3Paths,lsD3Polygons,lsD3Quadtrees,lsD3Queues,lsD3RandomNumbers,lsD3Requests,lsD3Scales,lsD3Selections,lsD3Shapes,lsD3TimeFormats,lsD3TimeIntervals,lsD3Timers,lsD3Transitions,lsD3VoronoiDiagrams,lsD3Zooming
+
+syntax cluster lsD3Arrays	                  contains=lsD3ArraysStatistics,lsD3ArraysSearch,lsD3ArraysTransformations,lsD3ArraysHistograms,lsD3Axes,lsD3Arrays
+syntax keyword lsD3ArraysStatistics         contained min max extent sum mean median quantile variance deviation
+syntax keyword lsD3ArraysSearch             contained scan bisect bisectRight bisectLeft bisector ascending descending
+syntax keyword lsD3ArraysTransformations    contained merge pairs permute shuffle ticks tickStep range transpose zip
+syntax keyword lsD3ArraysHistograms         contained histogram thresholdFreedmanDiaconis thresholdScott thresholdSturges
+syntax keyword lsD3Axes                     contained axisTop axisRight axisBottom axisLeft
+syntax keyword lsD3Brushes                  contained brush brushX brushY brushSelection
+syntax keyword lsD3Chords                   contained chord ribbon
+
+syntax cluster lsD3Collections              contains=lsD3CollectionsObjects,lsD3CollectionsMaps,lsD3CollectionsSets,lsD3CollectionsNests
+syntax keyword lsD3CollectionsObjects       contained keys values entries
+syntax keyword lsD3CollectionsMaps          contained map
+syntax keyword lsD3CollectionsSets          contained set
+syntax keyword lsD3CollectionsNests         contained nest
+
+syntax keyword lsD3Colors                   contained color rgb hsl lab hcl cubehelix
+syntax keyword lsD3Dispatches               contained dispatch
+syntax keyword lsD3Dragging                 contained drag dragDisable dragEnable
+syntax keyword lsD3DelimiterSeparatedValues contained dsvFormat csvParse csvParseRows csvFormat csvFormatRows tsvParse tsvParseRows tsvFormat tsvFormatRows
+syntax keyword lsD3Easings                  contained easeLinear easePolyIn easePolyOut easePolyInOut easeQuad easeQuadIn easeQuadOut easeQuadInOut easeCubic easeCubicIn easeCubicOut easeCubicInOut easeSin easeSinIn easeSinOut easeSinInOut easeExp easeExpIn easeExpOut easeExpInOut easeCircle easeCircleIn easeCircleOut easeCircleInOut easeElastic easeElasticIn easeElasticOut easeElasticInOut easeBack easeBackIn easeBackOut easeBackInOut easeBounce easeBounceIn easeBounceOut easeBounceInOut
+syntax keyword lsD3Forces                   contained forceSimulation forceCenter forceCollide forceLink forceManyBody forceX forceY
+syntax keyword lsD3NumberFormats            contained format formatPrefix formatSpecifier formatLocale formatDefaultLocale precisionFixed precisionPrefix precisionRound
+syntax keyword lsD3Geographies              contained geoPath geoAlbers geoAlbersUsa geoAzimuthalEqualArea geoAzimuthalEquidistant geoConicConformal geoConicEqualArea geoConicEquidistant geoEquirectangular geoGnomonic geoMercator geoOrthographic geoStereographic geoTransverseMercator geoProjection geoProjectionMutator geoAzimuthalEqualAreaRaw geoAzimuthalEquidistantRaw geoConicConformalRaw geoConicEqualAreaRaw geoConicEquidistantRaw geoEquirectangularRaw geoGnomonicRaw geoMercatorRaw geoOrthographicRaw geoStereographicRaw geoTransverseMercatorRaw geoArea geoBounds geoCentroid geoDistance geoLength geoInterpolate geoRotation geoCircle geoGraticule geoClipExtent
+syntax keyword lsD3GeographiesStreams       contained geoStream
+syntax keyword lsD3GeographiesTransforms    contained geoIdentity geoTransform
+syntax keyword lsD3Hierarchies              contained hierarchy stratify cluster tree treemap treemapBinary treemapDice treemapSlice treemapSliceDice treemapSquarify treemapResquarify partition pack packSiblings packEnclose
+syntax keyword lsD3Interpolators            contained interpolate interpolateArray interpolateDate interpolateNumber interpolateObject interpolateRound interpolateString interpolateTransformCss interpolateTransformSvg interpolateZoom interpolateRgb interpolateRgbBasis interpolateRgbBasisClosed interpolateHsl interpolateHslLong interpolateLab interpolateHcl interpolateHclLong interpolateCubehelix interpolateCubehelixLong interpolateBasis interpolateBasisClosed quantize
+syntax keyword lsD3Paths                    contained path
+syntax keyword lsD3Polygons                 contained polygonArea polygonCentroid polygonHull polygonContains polygonLength
+syntax keyword lsD3Quadtrees                contained quadtree
+syntax keyword lsD3Queues                   contained queue
+syntax keyword lsD3RandomNumbers            contained randomUniform randomNormal randomLogNormal randomBates randomIrwinHall randomExponential
+syntax keyword lsD3Requests                 contained request csv html json text tsv xml
+syntax keyword lsD3Scales                   contained scaleLinear scalePow scaleSqrt scaleLog scaleIdentity scaleTime scaleUtc scaleSequential interpolateViridis interpolateInferno interpolateMagma interpolatePlasma interpolateWarm interpolateCool interpolateRainbow interpolateCubehelixDefault scaleQuantize scaleQuantile scaleThreshold scaleOrdinal scaleImplicit scaleBand scalePoint schemeCategory10 schemeCategory20 schemeCategory20b schemeCategory20c
+syntax keyword lsD3Selections               contained selection select selectAll matcher selector selectorAll window creator event customEvent mouse touch touches local namespace namespaces
+syntax keyword lsD3Shapes                   contained arc pie line radialLine area radialArea curveBasis curveBasisClosed curveBasisOpen curveBundle curveCardinal curveCardinalClosed curveCardinalOpen curveCatmullRom curveCatmullRomClosed curveCatmullRomOpen curveLinear curveLinearClosed curveMonotoneX curveMonotoneY curveNatural curveStep curveStepAfter curveStepBefore symbol symbols symbolCircle symbolCross symbolDiamond symbolSquare symbolStar symbolTriangle symbolWye stack stackOrderAscending stackOrderDescending stackOrderInsideOut stackOrderNone stackOrderReverse stackOffsetExpand stackOffsetNone stackOffsetSilhouette stackOffsetWiggle
+syntax keyword lsD3TimeFormats              contained timeFormat timeParse utcFormat utcParse isoFormat isoParse timeFormatLocale timeFormatDefaultLocale
+syntax keyword lsD3TimeIntervals            contained timeInterval timeMillisecond utcMillisecond timeMilliseconds utcMilliseconds timeSecond utcSecond timeSeconds utcSeconds timeMinute utcMinute timeMinutes utcMinutes timeHour utcHour timeHours utcHours timeDay utcDay timeDays utcDays timeWeek utcWeek timeWeeks utcWeeks timeSunday utcSunday timeSundays utcSundays timeMonday utcMonday timeMondays utcMondays timeTuesday utcTuesday timeTuesdays utcTuesdays timeWednesday utcWednesday timeWednesdays utcWednesdays timeThursday utcThursday timeThursdays utcThursdays timeFriday utcFriday timeFridays utcFridays timeSaturday utcSaturday timeSaturdays utcSaturdays timeMonth utcMonth timeMonths utcMonths timeYear utcYear timeYears utcYears
+syntax keyword lsD3Timers                   contained now timer timerFlush timeout interval
+syntax keyword lsD3Transitions              contained transition active interrupt
+syntax keyword lsD3VoronoiDiagrams          contained voronoi
+syntax keyword lsD3Zooming                  contained zoom zoomTransform zoomIdentity
+
+" Define the default highlighting.
+" For version 5.7 and earlier: only when not done already
+" For version 5.8 and later: only when an item doesn't have highlighting yet
+if version >= 508 || !exists("did_underscore_ls_syntax_inits")
+  if version < 508
+    let did_underscore_ls_syntax_inits = 1
+    command -nargs=+ HiLink hi link <args>
+  else
+    command -nargs=+ HiLink hi def link <args>
+  endif
+
+  HiLink lsD3                         Constant
+  HiLink lsD3ArraysStatistics         PreProc
+  HiLink lsD3ArraysSearch             PreProc
+  HiLink lsD3ArraysTransformations    PreProc
+  HiLink lsD3ArraysHistograms         PreProc
+  HiLink lsD3Axes                     PreProc
+  HiLink lsD3Brushes                  PreProc
+  HiLink lsD3Chords                   PreProc
+  HiLink lsD3CollectionsObjects       PreProc
+  HiLink lsD3CollectionsMaps          PreProc
+  HiLink lsD3CollectionsSets          PreProc
+  HiLink lsD3CollectionsNests         PreProc
+  HiLink lsD3Colors                   PreProc
+  HiLink lsD3Dispatches               PreProc
+  HiLink lsD3Dragging                 PreProc
+  HiLink lsD3DelimiterSeparatedValues PreProc
+  HiLink lsD3Easings                  PreProc
+  HiLink lsD3Forces                   PreProc
+  HiLink lsD3NumberFormats            PreProc
+  HiLink lsD3Geographies              PreProc
+  HiLink lsD3GeographiesStreams       PreProc
+  HiLink lsD3GeographiesTransforms    PreProc
+  HiLink lsD3Hierarchies              PreProc
+  HiLink lsD3Interpolators            PreProc
+  HiLink lsD3Paths                    PreProc
+  HiLink lsD3Polygons                 PreProc
+  HiLink lsD3Quadtrees                PreProc
+  HiLink lsD3Queues                   PreProc
+  HiLink lsD3RandomNumbers            PreProc
+  HiLink lsD3Requests                 PreProc
+  HiLink lsD3Scales                   PreProc
+  HiLink lsD3Selections               PreProc
+  HiLink lsD3Shapes                   PreProc
+  HiLink lsD3TimeFormats              PreProc
+  HiLink lsD3TimeIntervals            PreProc
+  HiLink lsD3Timers                   PreProc
+  HiLink lsD3Transitions              PreProc
+  HiLink lsD3VoronoiDiagrams          PreProc
+  HiLink lsD3Zooming                  PreProc
+
+  delcommand HiLink
+endif
+
+

--- a/autoload/syntax/d3.typescript.vim
+++ b/autoload/syntax/d3.typescript.vim
@@ -1,0 +1,109 @@
+" Vim syntax file
+" Language:    d3.v4 for typescript
+" Maintainer:  othree <othree@gmail.com>
+" Maintainer:  Sfinktah <sfinktah@othree.spamtrak.org>
+" Last Change: 2016/11/11
+" Version:     4.2.8.0
+" URL:         https://github.com/d3/d3/blob/master/API.md
+
+syntax keyword typescriptD3 d3                      containedin=ALLBUT,typescriptComment,typescriptLineComment,typescriptString,typescriptTemplate,typescriptTemplateSubstitution
+syntax cluster typescript_Functions                 contains=@typescriptD3Arrays,typescriptD3Axes,typescriptD3Brushes,typescriptD3Chords,@typescriptD3Collections,typescriptD3Colors,typescriptD3Dispatches,typescriptD3Dragging,typescriptD3DelimiterSeparatedValues,typescriptD3Easings,typescriptD3Forces,typescriptD3NumberFormats,typescriptD3Geographies,typescriptD3GeographiesStreams,typescriptD3GeographiesTransforms,typescriptD3Hierarchies,typescriptD3Interpolators,typescriptD3Paths,typescriptD3Polygons,typescriptD3Quadtrees,typescriptD3Queues,typescriptD3RandomNumbers,typescriptD3Requests,typescriptD3Scales,typescriptD3Selections,typescriptD3Shapes,typescriptD3TimeFormats,typescriptD3TimeIntervals,typescriptD3Timers,typescriptD3Transitions,typescriptD3VoronoiDiagrams,typescriptD3Zooming
+
+syntax cluster typescriptD3Arrays	                  contains=typescriptD3ArraysStatistics,typescriptD3ArraysSearch,typescriptD3ArraysTransformations,typescriptD3ArraysHistograms,typescriptD3Axes,typescriptD3Arrays
+syntax keyword typescriptD3ArraysStatistics         contained min max extent sum mean median quantile variance deviation
+syntax keyword typescriptD3ArraysSearch             contained scan bisect bisectRight bisectLeft bisector ascending descending
+syntax keyword typescriptD3ArraysTransformations    contained merge pairs permute shuffle ticks tickStep range transpose zip
+syntax keyword typescriptD3ArraysHistograms         contained histogram thresholdFreedmanDiaconis thresholdScott thresholdSturges
+syntax keyword typescriptD3Axes                     contained axisTop axisRight axisBottom axisLeft
+syntax keyword typescriptD3Brushes                  contained brush brushX brushY brushSelection
+syntax keyword typescriptD3Chords                   contained chord ribbon
+
+syntax cluster typescriptD3Collections              contains=typescriptD3CollectionsObjects,typescriptD3CollectionsMaps,typescriptD3CollectionsSets,typescriptD3CollectionsNests
+syntax keyword typescriptD3CollectionsObjects       contained keys values entries
+syntax keyword typescriptD3CollectionsMaps          contained map
+syntax keyword typescriptD3CollectionsSets          contained set
+syntax keyword typescriptD3CollectionsNests         contained nest
+
+syntax keyword typescriptD3Colors                   contained color rgb hsl lab hcl cubehelix
+syntax keyword typescriptD3Dispatches               contained dispatch
+syntax keyword typescriptD3Dragging                 contained drag dragDisable dragEnable
+syntax keyword typescriptD3DelimiterSeparatedValues contained dsvFormat csvParse csvParseRows csvFormat csvFormatRows tsvParse tsvParseRows tsvFormat tsvFormatRows
+syntax keyword typescriptD3Easings                  contained easeLinear easePolyIn easePolyOut easePolyInOut easeQuad easeQuadIn easeQuadOut easeQuadInOut easeCubic easeCubicIn easeCubicOut easeCubicInOut easeSin easeSinIn easeSinOut easeSinInOut easeExp easeExpIn easeExpOut easeExpInOut easeCircle easeCircleIn easeCircleOut easeCircleInOut easeElastic easeElasticIn easeElasticOut easeElasticInOut easeBack easeBackIn easeBackOut easeBackInOut easeBounce easeBounceIn easeBounceOut easeBounceInOut
+syntax keyword typescriptD3Forces                   contained forceSimulation forceCenter forceCollide forceLink forceManyBody forceX forceY
+syntax keyword typescriptD3NumberFormats            contained format formatPrefix formatSpecifier formatLocale formatDefaultLocale precisionFixed precisionPrefix precisionRound
+syntax keyword typescriptD3Geographies              contained geoPath geoAlbers geoAlbersUsa geoAzimuthalEqualArea geoAzimuthalEquidistant geoConicConformal geoConicEqualArea geoConicEquidistant geoEquirectangular geoGnomonic geoMercator geoOrthographic geoStereographic geoTransverseMercator geoProjection geoProjectionMutator geoAzimuthalEqualAreaRaw geoAzimuthalEquidistantRaw geoConicConformalRaw geoConicEqualAreaRaw geoConicEquidistantRaw geoEquirectangularRaw geoGnomonicRaw geoMercatorRaw geoOrthographicRaw geoStereographicRaw geoTransverseMercatorRaw geoArea geoBounds geoCentroid geoDistance geoLength geoInterpolate geoRotation geoCircle geoGraticule geoClipExtent
+syntax keyword typescriptD3GeographiesStreams       contained geoStream
+syntax keyword typescriptD3GeographiesTransforms    contained geoIdentity geoTransform
+syntax keyword typescriptD3Hierarchies              contained hierarchy stratify cluster tree treemap treemapBinary treemapDice treemapSlice treemapSliceDice treemapSquarify treemapResquarify partition pack packSiblings packEnclose
+syntax keyword typescriptD3Interpolators            contained interpolate interpolateArray interpolateDate interpolateNumber interpolateObject interpolateRound interpolateString interpolateTransformCss interpolateTransformSvg interpolateZoom interpolateRgb interpolateRgbBasis interpolateRgbBasisClosed interpolateHsl interpolateHslLong interpolateLab interpolateHcl interpolateHclLong interpolateCubehelix interpolateCubehelixLong interpolateBasis interpolateBasisClosed quantize
+syntax keyword typescriptD3Paths                    contained path
+syntax keyword typescriptD3Polygons                 contained polygonArea polygonCentroid polygonHull polygonContains polygonLength
+syntax keyword typescriptD3Quadtrees                contained quadtree
+syntax keyword typescriptD3Queues                   contained queue
+syntax keyword typescriptD3RandomNumbers            contained randomUniform randomNormal randomLogNormal randomBates randomIrwinHall randomExponential
+syntax keyword typescriptD3Requests                 contained request csv html json text tsv xml
+syntax keyword typescriptD3Scales                   contained scaleLinear scalePow scaleSqrt scaleLog scaleIdentity scaleTime scaleUtc scaleSequential interpolateViridis interpolateInferno interpolateMagma interpolatePlasma interpolateWarm interpolateCool interpolateRainbow interpolateCubehelixDefault scaleQuantize scaleQuantile scaleThreshold scaleOrdinal scaleImplicit scaleBand scalePoint schemeCategory10 schemeCategory20 schemeCategory20b schemeCategory20c
+syntax keyword typescriptD3Selections               contained selection select selectAll matcher selector selectorAll window creator event customEvent mouse touch touches local namespace namespaces
+syntax keyword typescriptD3Shapes                   contained arc pie line radialLine area radialArea curveBasis curveBasisClosed curveBasisOpen curveBundle curveCardinal curveCardinalClosed curveCardinalOpen curveCatmullRom curveCatmullRomClosed curveCatmullRomOpen curveLinear curveLinearClosed curveMonotoneX curveMonotoneY curveNatural curveStep curveStepAfter curveStepBefore symbol symbols symbolCircle symbolCross symbolDiamond symbolSquare symbolStar symbolTriangle symbolWye stack stackOrderAscending stackOrderDescending stackOrderInsideOut stackOrderNone stackOrderReverse stackOffsetExpand stackOffsetNone stackOffsetSilhouette stackOffsetWiggle
+syntax keyword typescriptD3TimeFormats              contained timeFormat timeParse utcFormat utcParse isoFormat isoParse timeFormatLocale timeFormatDefaultLocale
+syntax keyword typescriptD3TimeIntervals            contained timeInterval timeMillisecond utcMillisecond timeMilliseconds utcMilliseconds timeSecond utcSecond timeSeconds utcSeconds timeMinute utcMinute timeMinutes utcMinutes timeHour utcHour timeHours utcHours timeDay utcDay timeDays utcDays timeWeek utcWeek timeWeeks utcWeeks timeSunday utcSunday timeSundays utcSundays timeMonday utcMonday timeMondays utcMondays timeTuesday utcTuesday timeTuesdays utcTuesdays timeWednesday utcWednesday timeWednesdays utcWednesdays timeThursday utcThursday timeThursdays utcThursdays timeFriday utcFriday timeFridays utcFridays timeSaturday utcSaturday timeSaturdays utcSaturdays timeMonth utcMonth timeMonths utcMonths timeYear utcYear timeYears utcYears
+syntax keyword typescriptD3Timers                   contained now timer timerFlush timeout interval
+syntax keyword typescriptD3Transitions              contained transition active interrupt
+syntax keyword typescriptD3VoronoiDiagrams          contained voronoi
+syntax keyword typescriptD3Zooming                  contained zoom zoomTransform zoomIdentity
+
+" Define the default highlighting.
+" For version 5.7 and earlier: only when not done already
+" For version 5.8 and later: only when an item doesn't have highlighting yet
+if version >= 508 || !exists("did_underscore_typescript_syntax_inits")
+  if version < 508
+    let did_underscore_typescript_syntax_inits = 1
+    command -nargs=+ HiLink hi link <args>
+  else
+    command -nargs=+ HiLink hi def link <args>
+  endif
+
+  HiLink typescriptD3                         Constant
+  HiLink typescriptD3ArraysStatistics         PreProc
+  HiLink typescriptD3ArraysSearch             PreProc
+  HiLink typescriptD3ArraysTransformations    PreProc
+  HiLink typescriptD3ArraysHistograms         PreProc
+  HiLink typescriptD3Axes                     PreProc
+  HiLink typescriptD3Brushes                  PreProc
+  HiLink typescriptD3Chords                   PreProc
+  HiLink typescriptD3CollectionsObjects       PreProc
+  HiLink typescriptD3CollectionsMaps          PreProc
+  HiLink typescriptD3CollectionsSets          PreProc
+  HiLink typescriptD3CollectionsNests         PreProc
+  HiLink typescriptD3Colors                   PreProc
+  HiLink typescriptD3Dispatches               PreProc
+  HiLink typescriptD3Dragging                 PreProc
+  HiLink typescriptD3DelimiterSeparatedValues PreProc
+  HiLink typescriptD3Easings                  PreProc
+  HiLink typescriptD3Forces                   PreProc
+  HiLink typescriptD3NumberFormats            PreProc
+  HiLink typescriptD3Geographies              PreProc
+  HiLink typescriptD3GeographiesStreams       PreProc
+  HiLink typescriptD3GeographiesTransforms    PreProc
+  HiLink typescriptD3Hierarchies              PreProc
+  HiLink typescriptD3Interpolators            PreProc
+  HiLink typescriptD3Paths                    PreProc
+  HiLink typescriptD3Polygons                 PreProc
+  HiLink typescriptD3Quadtrees                PreProc
+  HiLink typescriptD3Queues                   PreProc
+  HiLink typescriptD3RandomNumbers            PreProc
+  HiLink typescriptD3Requests                 PreProc
+  HiLink typescriptD3Scales                   PreProc
+  HiLink typescriptD3Selections               PreProc
+  HiLink typescriptD3Shapes                   PreProc
+  HiLink typescriptD3TimeFormats              PreProc
+  HiLink typescriptD3TimeIntervals            PreProc
+  HiLink typescriptD3Timers                   PreProc
+  HiLink typescriptD3Transitions              PreProc
+  HiLink typescriptD3VoronoiDiagrams          PreProc
+  HiLink typescriptD3Zooming                  PreProc
+
+  delcommand HiLink
+endif
+
+

--- a/autoload/syntax/jquery.javascript.vim
+++ b/autoload/syntax/jquery.javascript.vim
@@ -56,7 +56,7 @@ syntax keyword javascriptQMiscellaneous  contained index toArray
 syntax keyword javascriptQOffset         contained offset offsetParent position scrollTop scrollLeft
 syntax keyword javascriptQTraversing     contained eq filter first has is last map not slice
 syntax keyword javascriptQTraversing     contained add andBack contents end
-syntax keyword javascriptQTraversing     contained children closest find next nextAll nextUntil parent parents parentsUntil prev prevAll prevUntil siblings andSelf
+syntax keyword javascriptQTraversing     contained children closest find next nextAll nextUntil parent parents parentsUntil prev prevAll prevUntil siblings
 
 
 " selector

--- a/autoload/syntax/jquery.javascript.vim
+++ b/autoload/syntax/jquery.javascript.vim
@@ -56,7 +56,7 @@ syntax keyword javascriptQMiscellaneous  contained index toArray
 syntax keyword javascriptQOffset         contained offset offsetParent position scrollTop scrollLeft
 syntax keyword javascriptQTraversing     contained eq filter first has is last map not slice
 syntax keyword javascriptQTraversing     contained add andBack contents end
-syntax keyword javascriptQTraversing     contained children closest find next nextAll nextUntil parent parents parentsUntil prev prevAll prevUntil siblings
+syntax keyword javascriptQTraversing     contained children closest find next nextAll nextUntil parent parents parentsUntil prev prevAll prevUntil siblings andSelf
 
 
 " selector


### PR DESCRIPTION
This adds syntax for [d3/d3: Bring data to life with SVG, Canvas and HTML.](https://github.com/d3/d3).

Because of the many changes between the version 3 and version 4 (current) namespace, adding support for both versions would be counter-productive, highlighting incorrect syntax as valid.

There also seems to be a small addition to jQuery (addition of `andSelf`) that has nothing to do with d3, so LMK if you want that removed and added separately.

BTW, is there an automated process for generating all 4 syntax files?  It seemed rather pointless replacing **javascript** with **typescript**, saving, then moving to the next. 